### PR TITLE
Fix typo in readme (`ddev get`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Highlights include:
 ## Getting started
 
 ```console
-ddev addon get https://github.com/deviantintegral/ddev-playwright
+ddev get https://github.com/deviantintegral/ddev-playwright
 git add .
 git add -f .ddev/config.playwright.yml
 mkdir -p test/playwright

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Highlights include:
 ## Getting started
 
 ```console
-ddev get https://github.com/deviantintegral/ddev-playwright
+ddev get deviantintegral/ddev-playwright
 git add .
 git add -f .ddev/config.playwright.yml
 mkdir -p test/playwright


### PR DESCRIPTION
Minor TYPO in README. (`ddev get` is correct instead of `ddev addon get`)

Also, would you consider adding the `ddev-get` label to this repo so it's discoverable with `ddev get --list --all`? 

And of course, when it's matured to your liking, consider moving into ddev namespace and making official. 