### PR TITLE
feat: trust DDEV's mkcert root CA in Playwright's Chromium, Firefox, and WebKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ this addon imports that root into the web user's NSS database
 already seeds, so it works too.
 
 Firefox keeps its trust store inside each Playwright-managed profile and
-does not read `~/.pki/nssdb`, so `ignoreHTTPSErrors: true` is still needed
-for Firefox-only projects. A follow-up to auto-trust certificates in the
+does not read `~/.pki/nssdb`. If any Playwright project in your config
+targets Firefox, set `ignoreHTTPSErrors: true` on that project (or
+globally under `use`). A follow-up to auto-trust certificates in the
 Firefox profile would close that gap.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -82,17 +82,19 @@ Because tmpfs is volatile, `ddev restart` will clear the volume.
 ## HTTPS certificates
 
 DDEV signs every `*.ddev.site` certificate with a per-host
-[mkcert](https://github.com/FiloSottile/mkcert) root CA. On container start
-this addon imports that root into the web user's NSS database
-(`~/.pki/nssdb`), so Chromium-based browsers trust the certificate without
-`ignoreHTTPSErrors: true`. WebKit consults the system CA bundle that DDEV
-already seeds, so it works too.
+[mkcert](https://github.com/FiloSottile/mkcert) root CA. On container
+start this addon makes Chromium, Firefox, and WebKit all trust that CA,
+so `*.ddev.site` loads cleanly without `ignoreHTTPSErrors: true` in any
+Playwright project. The setup lives in
+`.ddev/web-entrypoint.d/mkcert-nssdb.sh`:
 
-Firefox keeps its trust store inside each Playwright-managed profile and
-does not read `~/.pki/nssdb`. If any Playwright project in your config
-targets Firefox, set `ignoreHTTPSErrors: true` on that project (or
-globally under `use`). A follow-up to auto-trust certificates in the
-Firefox profile would close that gap.
+- **Chromium** reads `~/.pki/nssdb`; the script imports every mkcert
+  root via `certutil`.
+- **Firefox** (the Playwright build) reads an enterprise policy JSON
+  whose path is given by `PLAYWRIGHT_FIREFOX_POLICIES_JSON`. The script
+  writes that file; `config.playwright.yml` sets the env var.
+- **WebKit** reads the system CA bundle directly, which DDEV already
+  seeds, so it needs no extra handling.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ ddev exec -d /var/www/html/test/playwright npm init playwright@latest
 # Or yarn:
 # ddev exec -d /var/www/html/test/playwright yarn create playwright
 
-# Add ignoreHTTPSErrors: true in test/playwright/playwright.config.ts to support HTTPS in tests.
-
 # 3. Install Playwright browser dependencies and cache them.
 ddev install-playwright
 
@@ -80,6 +78,20 @@ package uses this path for per-test SQLite database copies, and keeping
 the I/O in memory significantly improves parallel test performance. Feel free to use it for your own database driven tests.
 
 Because tmpfs is volatile, `ddev restart` will clear the volume.
+
+## HTTPS certificates
+
+DDEV signs every `*.ddev.site` certificate with a per-host
+[mkcert](https://github.com/FiloSottile/mkcert) root CA. On container start
+this addon imports that root into the web user's NSS database
+(`~/.pki/nssdb`), so Chromium-based browsers trust the certificate without
+`ignoreHTTPSErrors: true`. WebKit consults the system CA bundle that DDEV
+already seeds, so it works too.
+
+Firefox keeps its trust store inside each Playwright-managed profile and
+does not read `~/.pki/nssdb`, so `ignoreHTTPSErrors: true` is still needed
+for Firefox-only projects. A follow-up to auto-trust certificates in the
+Firefox profile would close that gap.
 
 ## Contributing
 

--- a/commands/host/install-playwright
+++ b/commands/host/install-playwright
@@ -16,8 +16,6 @@ if [ ! -f test/playwright/package.json ]; then
   echo "Answer "no" when it asks to install browsers and operating system dependencies,"
   echo "as those will be erased when ddev restarts."
   echo ""
-  echo "As well, add ignoreHTTPSErrors: true to playwright.config.ts."
-  echo ""
   echo "See https://playwright.dev/docs/intro for more details."
   echo ""
   echo "When done, run: ddev install-playwright"

--- a/config.playwright.yml
+++ b/config.playwright.yml
@@ -18,6 +18,11 @@ hooks:
     - exec-host: rm -rf .ddev/web-build/playwright
 web_environment:
   - DISPLAY=:1
+  # Playwright's bundled Firefox reads enterprise policies from the file
+  # referenced by this env var (see web-entrypoint.d/mkcert-nssdb.sh for
+  # the writer). Keeps *.ddev.site trusted for Firefox without requiring
+  # `ignoreHTTPSErrors: true`.
+  - PLAYWRIGHT_FIREFOX_POLICIES_JSON=/tmp/playwright-firefox-policies.json
 # We add the sleep so this doesn't error out when not using playwright.
 web_extra_daemons:
   - name: "kasmvnc"

--- a/install.yaml
+++ b/install.yaml
@@ -16,6 +16,7 @@ project_files:
   - web-build/xstartup
   - config.playwright.yml
   - docker-compose.sqlite.yaml
+  - web-entrypoint.d/mkcert-nssdb.sh
 
 # Manage .gitignore entries via post_install_actions so other addons (e.g.
 # ddev-playwright-cli) can append their own entries without being overwritten.

--- a/tests/testdata/npm-playwright/playwright.config.ts
+++ b/tests/testdata/npm-playwright/playwright.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    ignoreHTTPSErrors: true,
+    // Proves the addon's mkcert trust setup works across all three browsers.
+    // If this regresses, the bats suite will fail loudly on page.goto().
+    ignoreHTTPSErrors: false,
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
 

--- a/tests/testdata/yarn-playwright/playwright.config.ts
+++ b/tests/testdata/yarn-playwright/playwright.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    ignoreHTTPSErrors: true,
+    // Proves the addon's mkcert trust setup works across all three browsers.
+    // If this regresses, the bats suite will fail loudly on page.goto().
+    ignoreHTTPSErrors: false,
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://127.0.0.1:3000',
 

--- a/web-build/disabled.Dockerfile.playwright
+++ b/web-build/disabled.Dockerfile.playwright
@@ -61,10 +61,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && sudo -u $username mkdir -p /home/$username/.cache \
   && sudo -u $username cp -a /ms-playwright-cache/* /home/$username/.cache/
 
-# Install a window manager.
+# Install a window manager, plus libnss3-tools so the web-entrypoint.d
+# mkcert-nssdb.sh script can populate the user's NSS database with DDEV's
+# mkcert root CA — required for Chromium-based browsers to trust
+# *.ddev.site HTTPS certificates without `ignoreHTTPSErrors`.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,target=/var/lib/apt,sharing=locked \
   sudo apt-get install -y icewm \
+    libnss3-tools \
     xauth
 
 # Install kasmvnc for remote access.

--- a/web-entrypoint.d/mkcert-nssdb.sh
+++ b/web-entrypoint.d/mkcert-nssdb.sh
@@ -1,0 +1,45 @@
+#ddev-generated
+# Import DDEV's mkcert root CA into the web user's NSS shared database so
+# Chromium-based browsers (Playwright, Cypress, Puppeteer, etc.) trust
+# *.ddev.site certificates without setting `ignoreHTTPSErrors: true`.
+#
+# DDEV already adds the CA to the OpenSSL system bundle, which curl, wget,
+# openssl, and Node's default HTTPS agent all consult. Chromium on Linux
+# does not read that bundle; it uses its built-in root store plus the NSS
+# database at ~/.pki/nssdb for user-added roots.
+#
+# DDEV sources entrypoint scripts from /start.sh rather than executing
+# them, so the body runs in a subshell to contain `set -e` and any errors.
+# The script runs as the web user (not root); certutil comes from the
+# libnss3-tools package installed by Dockerfile.playwright.
+(
+  set -eo pipefail
+
+  if ! command -v certutil >/dev/null 2>&1; then
+    # libnss3-tools is only installed when Playwright is enabled via
+    # `ddev install-playwright`. Silently skip otherwise.
+    exit 0
+  fi
+
+  shopt -s nullglob
+  certs=(/usr/local/share/ca-certificates/mkcert_*.crt)
+  if [ ${#certs[@]} -eq 0 ]; then
+    exit 0
+  fi
+
+  nssdb="$HOME/.pki/nssdb"
+  mkdir -p "$nssdb"
+  chmod 0700 "$HOME/.pki" "$nssdb"
+
+  # Probe the DB; any failure (missing or corrupt) means we re-create it.
+  if ! certutil -d "sql:$nssdb" -L >/dev/null 2>&1; then
+    rm -f "$nssdb"/cert9.db "$nssdb"/key4.db "$nssdb"/pkcs11.txt
+    certutil -d "sql:$nssdb" -N --empty-password
+  fi
+
+  for cert in "${certs[@]}"; do
+    nick="mkcert $(basename "$cert" .crt)"
+    certutil -d "sql:$nssdb" -D -n "$nick" >/dev/null 2>&1 || true
+    certutil -d "sql:$nssdb" -A -t "C,," -n "$nick" -i "$cert"
+  done
+) || echo "mkcert-nssdb: NSS DB import failed (non-fatal)" >&2

--- a/web-entrypoint.d/mkcert-nssdb.sh
+++ b/web-entrypoint.d/mkcert-nssdb.sh
@@ -1,12 +1,21 @@
 #ddev-generated
-# Import DDEV's mkcert root CA into the web user's NSS shared database so
-# Chromium-based browsers (Playwright, Cypress, Puppeteer, etc.) trust
-# *.ddev.site certificates without setting `ignoreHTTPSErrors: true`.
+# Teach Playwright's browsers to trust DDEV's mkcert root CA so
+# *.ddev.site certificates load without `ignoreHTTPSErrors: true`.
 #
-# DDEV already adds the CA to the OpenSSL system bundle, which curl, wget,
-# openssl, and Node's default HTTPS agent all consult. Chromium on Linux
-# does not read that bundle; it uses its built-in root store plus the NSS
-# database at ~/.pki/nssdb for user-added roots.
+# Two pieces run here:
+#   1. Import every /usr/local/share/ca-certificates/mkcert_*.crt into the
+#      web user's NSS shared database (~/.pki/nssdb). Chromium on Linux
+#      consults NSS for user-added roots; this covers Chromium and
+#      Chromium-based tools (Cypress, Puppeteer, etc.). DDEV already adds
+#      the CA to the OpenSSL bundle that curl/wget/openssl/Node read, so
+#      those were never broken.
+#   2. Write a Firefox enterprise-policy JSON containing Certificates.Install
+#      and point the PLAYWRIGHT_FIREFOX_POLICIES_JSON env var at it via
+#      config.playwright.yml. Playwright patches its bundled Firefox to load
+#      policies from that env var (see playwright.cfg in the Firefox build),
+#      which lets us inject trust into the ephemeral profile Playwright
+#      creates for each test run. WebKit consults the system CA bundle
+#      directly and needs no extra handling.
 #
 # DDEV sources entrypoint scripts from /start.sh rather than executing
 # them, so the body runs in a subshell to contain `set -e` and any errors.
@@ -15,31 +24,49 @@
 (
   set -eo pipefail
 
-  if ! command -v certutil >/dev/null 2>&1; then
-    # libnss3-tools is only installed when Playwright is enabled via
-    # `ddev install-playwright`. Silently skip otherwise.
-    exit 0
-  fi
-
   shopt -s nullglob
   certs=(/usr/local/share/ca-certificates/mkcert_*.crt)
   if [ ${#certs[@]} -eq 0 ]; then
     exit 0
   fi
 
-  nssdb="$HOME/.pki/nssdb"
-  mkdir -p "$nssdb"
-  chmod 0700 "$HOME/.pki" "$nssdb"
+  # --- Chromium / NSS ----------------------------------------------------
+  if command -v certutil >/dev/null 2>&1; then
+    nssdb="$HOME/.pki/nssdb"
+    mkdir -p "$nssdb"
+    chmod 0700 "$HOME/.pki" "$nssdb"
 
-  # Probe the DB; any failure (missing or corrupt) means we re-create it.
-  if ! certutil -d "sql:$nssdb" -L >/dev/null 2>&1; then
-    rm -f "$nssdb"/cert9.db "$nssdb"/key4.db "$nssdb"/pkcs11.txt
-    certutil -d "sql:$nssdb" -N --empty-password
+    # Probe the DB; any failure (missing or corrupt) means we re-create it.
+    if ! certutil -d "sql:$nssdb" -L >/dev/null 2>&1; then
+      rm -f "$nssdb"/cert9.db "$nssdb"/key4.db "$nssdb"/pkcs11.txt
+      certutil -d "sql:$nssdb" -N --empty-password
+    fi
+
+    for cert in "${certs[@]}"; do
+      nick="mkcert $(basename "$cert" .crt)"
+      certutil -d "sql:$nssdb" -D -n "$nick" >/dev/null 2>&1 || true
+      certutil -d "sql:$nssdb" -A -t "C,," -n "$nick" -i "$cert"
+    done
   fi
 
+  # --- Firefox / enterprise policy ---------------------------------------
+  # Matches PLAYWRIGHT_FIREFOX_POLICIES_JSON set in config.playwright.yml.
+  policies_path="/tmp/playwright-firefox-policies.json"
+  # Build a JSON array of cert paths. Paths under /usr/local/share/ca-
+  # certificates/ are controlled by DDEV and never contain quotes, so a
+  # direct literal is safe.
+  cert_list=""
   for cert in "${certs[@]}"; do
-    nick="mkcert $(basename "$cert" .crt)"
-    certutil -d "sql:$nssdb" -D -n "$nick" >/dev/null 2>&1 || true
-    certutil -d "sql:$nssdb" -A -t "C,," -n "$nick" -i "$cert"
+    [ -n "$cert_list" ] && cert_list+=", "
+    cert_list+="\"$cert\""
   done
-) || echo "mkcert-nssdb: NSS DB import failed (non-fatal)" >&2
+  cat > "$policies_path" <<EOF
+{
+  "policies": {
+    "Certificates": {
+      "Install": [$cert_list]
+    }
+  }
+}
+EOF
+) || echo "mkcert-nssdb: CA trust setup failed (non-fatal)" >&2


### PR DESCRIPTION
## Summary

Make `*.ddev.site` certificates trusted by all three browsers Playwright ships — Chromium, Firefox, and WebKit — so users don't need `ignoreHTTPSErrors: true` in their Playwright config.

- `web-entrypoint.d/mkcert-nssdb.sh` (new) imports every `mkcert_*.crt` from `/usr/local/share/ca-certificates/` into the web user's `~/.pki/nssdb` (for Chromium) **and** writes a Firefox enterprise policy JSON at `/tmp/playwright-firefox-policies.json`.
- `Dockerfile.playwright` installs `libnss3-tools` so `certutil` is available.
- `config.playwright.yml` sets `PLAYWRIGHT_FIREFOX_POLICIES_JSON=/tmp/playwright-firefox-policies.json`. Playwright's Firefox reads this env var at launch (see its bundled `playwright.cfg`) and applies the policy to the ephemeral profile it creates for each test.
- README's HTTPS section covers the three-browser story.

## Why

DDEV installs its mkcert root into `/etc/ssl/certs/ca-certificates.crt`, which is enough for `curl`, `wget`, `openssl`, Node's default HTTPS agent, and WebKit (WebKitGTK reads the system bundle via GTlsDatabase). Chromium and Firefox don't.

- **Chromium on Linux** uses its built-in root store plus the NSS shared DB at `~/.pki/nssdb`. The DDEV webimage ships `libnss3` (the library) but not `libnss3-tools` (the `certutil` admin tool) and never populates an NSS DB.
- **Firefox (Playwright build)** has Mozilla's normal policies.json discovery *replaced* by a Playwright-specific `PlaywrightPoliciesProvider` that only reads the path named by `browser.policies.alternatePath`. That pref is set from the `PLAYWRIGHT_FIREFOX_POLICIES_JSON` env var via `playwright.cfg`. Dropping a `policies.json` in `/etc/firefox/policies/` or the Firefox install's `distribution/` dir does nothing in this build. See `modules/EnterprisePoliciesParent.sys.mjs` inside `browser/omni.ja` (the `// --- Playwright begin ---` block).

Without this, every `page.goto()` against `*.ddev.site` fails with `net::ERR_CERT_AUTHORITY_INVALID` (Chromium) or `SEC_ERROR_UNKNOWN_ISSUER` (Firefox) unless the user sets `ignoreHTTPSErrors: true`.

## Implementation notes

- Entrypoint scripts in `.ddev/web-entrypoint.d/*.sh` are **sourced** (not executed) by `/start.sh`, so bare `set -e` at the top level leaks and crashes the container on any failure. The script body runs in a subshell with `( set -eo pipefail; … ) || echo "…non-fatal…"`.
- The entrypoint runs as the **web user** (the UID that maps to the host user), not root. `sudo -u $user` and `runuser -u $user` both fail in that context; the script uses `$HOME/.pki/nssdb` and writes the Firefox policy to `/tmp/` (container-local, writable, re-written every start so stale files don't matter).
- The `#ddev-generated` marker on the new script means `ddev add-on remove` will strip it automatically (no `removal_actions` change needed).
- `libnss3-tools` is only installed when `ddev install-playwright` is run (Dockerfile is opt-in), so projects that only use the addon for `config.playwright.yml` / the SQLite tmpfs mount don't pay for it. The Chromium/NSS branch of the entrypoint no-ops silently when `certutil` is absent. The Firefox branch still writes `/tmp/playwright-firefox-policies.json` unconditionally — the env var is harmless if Firefox isn't installed.

## Test plan

Validated in a downstream project (`lullabot.com-d8`) by prototyping the same pieces as project-local files, flipping `ignoreHTTPSErrors` to `false`, adding a Firefox project alongside Chromium, and running `ddev playwright test tests/e2e/content-types/article.spec.ts` per project:

- [x] Chromium — before fix: `net::ERR_CERT_AUTHORITY_INVALID`. After: passes.
- [x] Firefox — before fix: `SEC_ERROR_UNKNOWN_ISSUER`. After: passes.
- [x] `certutil -d sql:$HOME/.pki/nssdb -L` shows the mkcert CA on the container.
- [x] `/tmp/playwright-firefox-policies.json` is written with the correct `Certificates.Install` array.
- [x] Addon bats suite (`tests/test.bats`) passed on the previous commit; CI will rerun for this one.
- [ ] Not tested: multiple mkcert roots (shouldn't happen in practice — DDEV maintains one per host — but the loop handles it).

## Follow-up ideas

- Drop `ignoreHTTPSErrors: true` from `tests/testdata/*/playwright.config.ts` so the addon's own bats tests assert the fix.
- Document that users who previously set `ignoreHTTPSErrors: true` can remove it after upgrading.